### PR TITLE
feat: add iframely to crawler user-agent list

### DIFF
--- a/nginx-php/nginx.conf
+++ b/nginx-php/nginx.conf
@@ -60,7 +60,8 @@ http {
         "~*chrome-lighthouse"                       1;
         "~*telegrambot"                             1;
         "~*google-inspectiontool"                   1;
-        "~*petalbot"                                1;        
+        "~*petalbot"                                1;
+        "~*iframely"                                1;
     }
 
     map $args $prerender_args {

--- a/nginx-reverse-proxy/nginx.conf
+++ b/nginx-reverse-proxy/nginx.conf
@@ -50,6 +50,7 @@ http {
         "~*telegrambot"                             1;
         "~*google-inspectiontool"                   1;
         "~*petalbot"                                1;
+        "~*iframely"                                1;
     }
 
     map $args $prerender_args {

--- a/nginx.conf
+++ b/nginx.conf
@@ -55,6 +55,7 @@ http {
         "~*telegrambot"                             1;
         "~*google-inspectiontool"                   1;
         "~*petalbot"                                1;
+        "~*iframely"                                1;
     }
 
     map $args $prerender_args {


### PR DESCRIPTION
Adds `iframely` to the crawler user-agent list so Iframely requests are routed through Prerender.