### PR TITLE
fix: ignore modern static-asset extensions

### DIFF
--- a/nginx-php/nginx.conf
+++ b/nginx-php/nginx.conf
@@ -76,7 +76,7 @@ http {
 
     map $uri $prerender {
         default $x_prerender;
-        "~*\.(js|css|xml|less|png|jpg|jpeg|gif|pdf|txt|ico|rss|zip|mp3|rar|exe|wmv|doc|avi|ppt|mpg|mpeg|tif|wav|mov|psd|ai|xls|mp4|m4a|swf|dat|dmg|iso|flv|m4v|torrent|ttf|woff|woff2|svg|eot)" 0;
+        "~*\.(js|css|xml|less|png|jpg|jpeg|gif|pdf|txt|ico|rss|zip|mp3|rar|exe|wmv|doc|avi|ppt|mpg|mpeg|tif|wav|mov|psd|ai|xls|mp4|m4a|swf|dat|dmg|iso|flv|m4v|torrent|ttf|woff|woff2|svg|eot|otf|webp|avif|webmanifest)" 0;
     }
 
     # log_format prerender_debug '[$time_local] $remote_addr - $remote_user - $server_name user-agent: $http_user_agent prerender: $prerender: $request to: $upstream_addr upstream_response_time: $upstream_response_time msec $msec request_time $request_time';

--- a/nginx-reverse-proxy/nginx.conf
+++ b/nginx-reverse-proxy/nginx.conf
@@ -65,7 +65,7 @@ http {
 
     map $uri $prerender {
         default $x_prerender;
-        "~*\.(js|css|xml|less|png|jpg|jpeg|gif|pdf|txt|ico|rss|zip|mp3|rar|exe|wmv|doc|avi|ppt|mpg|mpeg|tif|wav|mov|psd|ai|xls|mp4|m4a|swf|dat|dmg|iso|flv|m4v|torrent|ttf|woff|woff2|svg|eot)" 0;
+        "~*\.(js|css|xml|less|png|jpg|jpeg|gif|pdf|txt|ico|rss|zip|mp3|rar|exe|wmv|doc|avi|ppt|mpg|mpeg|tif|wav|mov|psd|ai|xls|mp4|m4a|swf|dat|dmg|iso|flv|m4v|torrent|ttf|woff|woff2|svg|eot|otf|webp|avif|webmanifest)" 0;
     }
 
 

--- a/nginx.conf
+++ b/nginx.conf
@@ -70,7 +70,7 @@ http {
 
     map $uri $prerender {
         default $x_prerender;
-        "~*\.(js|css|xml|less|png|jpg|jpeg|gif|pdf|txt|ico|rss|zip|mp3|rar|exe|wmv|doc|avi|ppt|mpg|mpeg|tif|wav|mov|psd|ai|xls|mp4|m4a|swf|dat|dmg|iso|flv|m4v|torrent|ttf|woff|woff2|svg|eot)" 0;
+        "~*\.(js|css|xml|less|png|jpg|jpeg|gif|pdf|txt|ico|rss|zip|mp3|rar|exe|wmv|doc|avi|ppt|mpg|mpeg|tif|wav|mov|psd|ai|xls|mp4|m4a|swf|dat|dmg|iso|flv|m4v|torrent|ttf|woff|woff2|svg|eot|otf|webp|avif|webmanifest)" 0;
     }
 
     server {


### PR DESCRIPTION
## The bug

The `map $uri $prerender` static-asset ignore regex is missing modern asset extensions (`otf`, `webp`, `avif`, `webmanifest`). When a crawler requests one of these assets, the request is proxied to the Prerender rendering service, which rejects static assets with a **504** — so the crawler sees a 5xx on an asset that serves `200` for normal users.

## Live evidence

Verified against prerender.io's own site: Googlebot UA requesting `inter-*.woff2` receives **504**, while a normal UA receives **200**. Any forwarded font/image request surfaces as a crawler-visible 5xx.

## Canonical reference

This propagates the canonical static-asset ignore list from prerender/integration-contract#1, which adds `.woff2 .otf .eot .webp .avif .webmanifest` (`woff2` and `eot` were already present here).

## Changes

Added `otf|webp|avif|webmanifest` to the extension alternation in the identical `map $uri $prerender` block of all three configs:

- `nginx.conf`
- `nginx-php/nginx.conf`
- `nginx-reverse-proxy/nginx.conf`

## Caveats

- The `~*` regex is case-insensitive and **unanchored**, so `avi` already incidentally covered `avif` (and `doc` covers `docx`, etc.). The explicit entries match the canonical contract list; adding a `$` anchor would change matching behavior for URLs that merely contain these substrings, so it is deliberately out of scope for this PR. The flip side of staying unanchored is continued over-matching, e.g. a page URL like `/blog/why-we-love-avif` is treated as a static asset and never prerendered.
- No test suite; the nginx binary wasn't available, so the config change was validated visually (single-line regex edit inside an existing `map` block).

🤖 Generated with [Claude Code](https://claude.com/claude-code)